### PR TITLE
Add homebrew path for macOS

### DIFF
--- a/Microsoft.Learn.AzureFunctionsTesting/FunctionHostSettings.cs
+++ b/Microsoft.Learn.AzureFunctionsTesting/FunctionHostSettings.cs
@@ -43,6 +43,9 @@ namespace Microsoft.Learn.AzureFunctionsTesting
                 // global npm folder for CI builds
                 pathsToTry.Add("C:\\npm\\prefix\\node_modules\\azure-functions-core-tools\\bin\\func.exe");
 
+                // homebrew folder for mac
+                pathsToTry.Add("/opt/homebrew/bin/func");
+
                 foreach (var pathToTry in pathsToTry)
                 {
                     if (File.Exists(pathToTry))


### PR DESCRIPTION
In order to use this library on Mac, we need to add the `homebrew` path to use azure function core tools.
You can find the azure core tools installation guide for mac [HERE](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local?tabs=macos%2Cisolated-process%2Cnode-v4%2Cpython-v2%2Chttp-trigger%2Ccontainer-apps&pivots=programming-language-csharp#install-the-azure-functions-core-tools). 