### PR TITLE
Specify --enableAuth on func.exe by default

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <Authors>Microsoft</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>

--- a/Microsoft.Learn.AzureFunctionsTesting/FunctionFixture.cs
+++ b/Microsoft.Learn.AzureFunctionsTesting/FunctionFixture.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Learn.AzureFunctionsTesting
                 StartInfo =
                 {
                     FileName = functionsHostExePath,
-                    Arguments = $"start -p {builder.Port}",
+                    Arguments = $"start -p {builder.Port} {(builder.EnableAuth ? "--enableAuth" : null)}",
                     WorkingDirectory = functionAppPath
                 }
             };

--- a/Microsoft.Learn.AzureFunctionsTesting/FunctionTestConfigurationBuilder.cs
+++ b/Microsoft.Learn.AzureFunctionsTesting/FunctionTestConfigurationBuilder.cs
@@ -16,6 +16,8 @@ namespace Microsoft.Learn.AzureFunctionsTesting
 
         internal string? FunctionAppPath { get; set; } = null;
 
+        internal bool EnableAuth { get; set; } = true;
+
         internal int Port { get; set; } = 7071;
 
         internal int StartupTimeout { get; set; } = 15;
@@ -36,6 +38,10 @@ namespace Microsoft.Learn.AzureFunctionsTesting
             return (T?)plugin;
         }
 
+        public void DisableFunctionsAuth()
+        {
+            this.EnableAuth = false;
+        }
 
         public void SetFunctionAppPath(string path)
         {

--- a/Microsoft.Learn.AzureFunctionsTesting/README.md
+++ b/Microsoft.Learn.AzureFunctionsTesting/README.md
@@ -98,6 +98,7 @@ See below for a complete example:
                 // [Optional] You can set these values if necessary
                 //builder.SetStartupTimeout(180);
                 //builder.SetFunctionAppPort(7081);
+                //builder.DisableFunctionsAuth();
 
                 // Set up any mocks or other test run configuration as required
                 var emailService = builder.UseMockServer<EmailServer>("emailServer");

--- a/Sample/MyFunctionApp/MyFunctions.cs
+++ b/Sample/MyFunctionApp/MyFunctions.cs
@@ -64,5 +64,15 @@ namespace MyFunctionApp
             await response.WriteAsJsonAsync(true);
             return response;
         }
+
+        [Function("AuthRequired")]
+        public HttpResponseData AuthRequired([HttpTrigger(AuthorizationLevel.Function, "get", Route = "auth-required")] HttpRequestData req)
+        {
+            logger.LogInformation("AuthRequired called");
+
+            var response = req.CreateResponse(HttpStatusCode.OK);
+
+            return response;
+        }
     }
 }

--- a/Sample/Tests.MyFunctionApp/AuthRequiredTests.cs
+++ b/Sample/Tests.MyFunctionApp/AuthRequiredTests.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.Learn.AzureFunctionsTesting;
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Tests.MyFunctionApp.Helpers;
+using Xunit;
+
+namespace Tests.MyFunctionApp
+{
+    public class AuthRequiredTests
+    {
+        private readonly FunctionFixture<TestStartup> fixture;
+
+        public AuthRequiredTests(FunctionFixture<TestStartup> fixture)
+        {
+            this.fixture = fixture;
+        }
+
+        [Fact]
+        public async Task AuthRequired_returns_401_when_not_authenticated()
+        {
+            // Arrange
+            var request = new HttpRequestMessage(HttpMethod.Get, "api/auth-required");
+
+            // Act
+            var response = await fixture.Client.SendAsync(request);
+
+            // Assert
+            Assert.True(response.StatusCode == HttpStatusCode.Unauthorized,
+                $"response.StatusCode is {response.StatusCode} but {HttpStatusCode.Unauthorized} was expected."
+                + Environment.NewLine
+                + "If this fails, ensure Azure Functions Core Tools is version 4.0.6821 or later. https://github.com/Azure/azure-functions-core-tools/releases/tag/4.0.6821");
+        }
+    }
+}

--- a/Sample/Tests.MyFunctionApp/Helpers/TestStartup.cs
+++ b/Sample/Tests.MyFunctionApp/Helpers/TestStartup.cs
@@ -30,6 +30,7 @@ namespace Tests.MyFunctionApp.Helpers
             // [Optional] You can set these values if necessary
             //builder.SetStartupTimeout(180);
             //builder.SetFunctionAppPort(7081);
+            //builder.DisableFunctionsAuth();
 
             // -- Set up any mocks or other test run configuration as required --
 


### PR DESCRIPTION
Specify --enableAuth on func.exe by default with the ability to disable it using DisableFunctionsAuth() to revert to default func.exe behavior. This enables integration testing with the same auth expectations as production.